### PR TITLE
use inifile::create_ini_settings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,5 +26,5 @@ class journald::config {
   $ini_settings = {
     'Journal' => $merged_options,
   }
-  create_ini_settings($ini_settings, $defaults)
+  inifile::create_ini_settings($ini_settings, $defaults)
 }


### PR DESCRIPTION
Just "create_ini_settings" is depcrecated. See https://github.com/puppetlabs/puppetlabs-inifile/blob/master/lib/puppet/functions/create_ini_settings.rb#L1